### PR TITLE
Update to TGI v1.0.2

### DIFF
--- a/tgi-compile-mila.sh
+++ b/tgi-compile-mila.sh
@@ -8,8 +8,9 @@
 set -e
 set -v
 
+TGI_VERSION='1.0.2'
+FLASH_ATTN_VERSION='2.0.8'
 export MAX_JOBS=4
-TGI_VERSION='1.0.0'
 
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
@@ -29,13 +30,13 @@ fi
 echo "Storing files in $(realpath $RELEASE_DIR)"
 mkdir -p $WORK_DIR
 
+# Load modules
+module load gcc/9.3.0
+
 # Create environment
 eval "$(~/bin/micromamba shell hook -s posix)"
-micromamba create -y -p $TMP_PYENV -c conda-forge python=3.11
+micromamba create -y -p $TMP_PYENV -c pytorch -c nvidia -c conda-forge 'python=3.11' 'git-lfs=3.3' 'pyarrow=12.0.1' 'pytorch==2.0.1' 'pytorch-cuda=11.8' 'cuda-nvcc=11.8' 'cudatoolkit=11.8' 'cuda-libraries=11.8' 'cuda-libraries-dev=11.8' 'cudnn=8.8' 'openssl=3' 'ninja=1'
 micromamba activate $TMP_PYENV
-micromamba config append channels conda-forge
-micromamba config append channels nodefaults
-micromamba install -y 'ninja=1' 'git-lfs=3.3' 'pytorch==2.0.1' 'pytorch-cuda=11.7' 'cuda-nvcc=11.7' 'cudatoolkit=11.7' 'cuda-libraries=11.7' 'cuda-libraries-dev=11.7' 'cudnn=8.8' 'openssl=3' 'gcc=11' 'gxx=11' -c pytorch -c nvidia
 export LD_LIBRARY_PATH=$TMP_PYENV/lib:$LD_LIBRARY_PATH
 export CPATH=$TMP_PYENV/include:$CPATH
 export LIBRARY_PATH=$TMP_PYENV/lib:$LIBRARY_PATH
@@ -66,21 +67,23 @@ git checkout tags/v${TGI_VERSION} -b v${TGI_VERSION}-branch
 ####
 # download and compile python dependencies
 ####
-# download
+# download dependencies
 cd $RELEASE_DIR/python_deps
 pip download 'grpcio-tools==1.51.1' 'mypy-protobuf==3.4.0' 'types-protobuf>=3.20.4'
 pip download -r $WORK_DIR/text-generation-inference/server/requirements.txt
-pip download --no-deps 'accelerate<0.20.0,>=0.19.0' 'bitsandbytes==0.39.1' 'poetry-core>=1.6.1'
-pip download --no-deps 'ninja' 'cmake' 'lit' 'packaging'
+pip download 'bitsandbytes<0.42.0,>=0.41.1' # bnb
+pip download 'datasets<3.0.0,>=2.14.0' 'texttable<2.0.0,>=1.6.7' # quantize
+pip download 'accelerate<0.21.0,>=0.20.0' # accelerate
+pip download --no-deps 'poetry-core>=1.6.1' 'ninja' 'cmake' 'lit' 'packaging' # build dependencies
 
 # build dependencies that are not pre-compiled
-pip wheel --no-index --no-deps --find-links $RELEASE_DIR/python_deps 'lit-16.0.6.tar.gz'
-rm lit-16.0.6.tar.gz
+pip wheel --no-index --no-deps --find-links $RELEASE_DIR/python_deps lit-*.tar.gz
+rm lit-*.tar.gz
 
 ####
 # BUILD tgi
 ####
-cd $WORK_DIR/text-generation-inference
+pip install --no-index --find-links $RELEASE_DIR/python_deps packaging
 
 #
 # build server
@@ -96,10 +99,9 @@ touch text_generation_server/pb/__init__.py
 rm text_generation_server/pb/.gitignore
 # build package
 pip install --no-index --find-links $RELEASE_DIR/python_deps 'poetry-core>=1.6.1'
-pip install --no-index --find-links $RELEASE_DIR/python_deps 'accelerate<0.20.0,>=0.19.0' 'bitsandbytes==0.39.1'
-pip wheel --no-deps --no-index --find-links $RELEASE_DIR/python_deps ".[bnb, accelerate]"
-cp text_generation_server-${TGI_VERSION}-py3-none-any.whl $RELEASE_DIR/python_ins/
-pip install --no-index --find-links $RELEASE_DIR/python_deps $RELEASE_DIR/python_ins/text_generation_server-${TGI_VERSION}-py3-none-any.whl
+pip wheel --no-deps --no-index --find-links $RELEASE_DIR/python_deps ".[bnb, accelerate, quantize]"
+# cp "text_generation_server-${TGI_VERSION}-py3-none-any.whl" $RELEASE_DIR/python_ins/
+cp text_generation_server-1.0.1-py3-none-any.whl $RELEASE_DIR/python_ins/
 
 #
 # build cli
@@ -123,9 +125,10 @@ cp $WORK_DIR/text-generation-inference/target/release/text-generation-benchmark 
 # build kernels
 #
 NV_CC="8.0;8.6" # flash-attention-v2 and exllama_kernels are anyway limited to CC of 8.0+
-pip install --no-index --find-links $RELEASE_DIR/python_deps packaging
 
 # flash-attention v2
+cd $RELEASE_DIR/python_ins
+
 # For some reason the Dockerfile in TGI, compiles flash_attention, rotary, and layer_norm
 # from flash-attention v1. And then compiles flash_attention from flash-attention v2.
 # However, this is redudant as rotary and layer_norm are nearly the same and
@@ -133,60 +136,53 @@ pip install --no-index --find-links $RELEASE_DIR/python_deps packaging
 # Therefore do only compile flash-attention v2.
 
 cd $WORK_DIR/text-generation-inference/server
-git clone https://github.com/HazyResearch/flash-attention.git flash-attention-v2
+git clone https://github.com/Dao-AILab/flash-attention flash-attention-v2
 cd $WORK_DIR/text-generation-inference/server/flash-attention-v2
-git checkout tags/v2.0.1
+git checkout tags/v${FLASH_ATTN_VERSION}
 
 # With 16GB of memory, MAX_JOBS=1 is as high as it goes.
 cd $WORK_DIR/text-generation-inference/server/flash-attention-v2
 TORCH_CUDA_ARCH_LIST=$NV_CC MAX_JOBS=1 python setup.py build
 TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
-wheel convert dist/flash_attn-2.0.1-py3.11-linux-x86_64.egg
-wheel tags --python-tag=cp311 flash_attn-2.0.1-py311-cp311-linux_x86_64.whl
-cp flash_attn-2.0.1-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
+wheel convert dist/flash_attn-${FLASH_ATTN_VERSION}-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 flash_attn-${FLASH_ATTN_VERSION}-py311-cp311-linux_x86_64.whl
+cp flash_attn-${FLASH_ATTN_VERSION}-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 cd $WORK_DIR/text-generation-inference/server/flash-attention-v2/csrc/rotary
-TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py build
+TORCH_CUDA_ARCH_LIST=$NV_CC FLASH_ATTENTION_FORCE_BUILD=True python setup.py build
 TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
 wheel convert dist/rotary_emb-0.1-py3.11-linux-x86_64.egg
 wheel tags --python-tag=cp311 rotary_emb-0.1-py311-cp311-linux_x86_64.whl
 cp rotary_emb-0.1-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 cd $WORK_DIR/text-generation-inference/server/flash-attention-v2/csrc/layer_norm
-TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py build
+TORCH_CUDA_ARCH_LIST=$NV_CC FLASH_ATTENTION_FORCE_BUILD=True python setup.py build
 TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
 wheel convert dist/dropout_layer_norm-0.1-py3.11-linux-x86_64.egg
 wheel tags --python-tag=cp311 dropout_layer_norm-0.1-py311-cp311-linux_x86_64.whl
 cp dropout_layer_norm-0.1-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 # vllm
-git clone https://github.com/OlivierDehaene/vllm.git $WORK_DIR/text-generation-inference/server/vllm
+cd $WORK_DIR/text-generation-inference/server
+make build-vllm
 cd $WORK_DIR/text-generation-inference/server/vllm
-git fetch && git checkout d284b831c17f42a8ea63369a06138325f73c4cf9
-# This patch is because CC 90 require CUDA 11.8+. However, CC 90 is for H100 only, which we don't have/need.
-git apply <<EOF
-diff --git a/setup.py b/setup.py
-index c53005a..8919cf3 100644
---- a/setup.py
-+++ b/setup.py
-@@ -49,7 +49,7 @@ for i in range(device_count):
-     compute_capabilities.add(major * 10 + minor)
- # If no GPU is available, add all supported compute capabilities.
- if not compute_capabilities:
--    compute_capabilities = {70, 75, 80, 86, 90}
-+    compute_capabilities = {70, 75, 80, 86}
- # Add target compute capabilities to NVCC flags.
- for capability in compute_capabilities:
-     NVCC_FLAGS += ["-gencode", f"arch=compute_{capability},code=sm_{capability}"]
-EOF
-python setup.py build
 python setup.py bdist_egg
 wheel convert dist/vllm-0.0.0-py3.11-linux-x86_64.egg
 wheel tags --python-tag=cp311 vllm-0.0.0-py311-cp311-linux_x86_64.whl
 cp vllm-0.0.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 # exllama_kernels
-# SKIP: because Mila does not support CUDA 11.8+ and it can be disabled
+cd $WORK_DIR/text-generation-inference/server/exllama_kernels
+TORCH_CUDA_ARCH_LIST=$NV_CC+PTX python setup.py build
+TORCH_CUDA_ARCH_LIST=$NV_CC+PTX python setup.py bdist_egg
+wheel convert dist/exllama_kernels-0.0.0-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 exllama_kernels-0.0.0-py311-cp311-linux_x86_64.whl
+cp exllama_kernels-0.0.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 # custom_kernels
-# SKIP: because Mila does not support CUDA 11.8+ and it can be disabled
+cd $WORK_DIR/text-generation-inference/server/custom_kernels
+TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py build
+TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
+wheel convert dist/custom_kernels-0.0.0-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 custom_kernels-0.0.0-py311-cp311-linux_x86_64.whl
+cp custom_kernels-0.0.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/

--- a/tgi-server-cc.sh
+++ b/tgi-server-cc.sh
@@ -9,6 +9,9 @@
 #SBATCH --time=2:59:00
 set -e
 
+TGI_VERSION='1.0.2'
+FLASH_ATTN_VERSION='2.0.8'
+
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
     RELEASE_DIR=$HOME/tgi-release
@@ -19,8 +22,9 @@ fi
 if [ -z "${TMP_PYENV}" ]; then
     TMP_PYENV=$SLURM_TMPDIR/tgl-env
 fi
+
 # Load modules
-module load python/3.11 gcc/11.3.0 git-lfs/3.3.0 rust/1.65.0 protobuf/3.21.3 cuda/11.8.0 cudnn/8.6.0.163
+module load python/3.11 gcc/9.3.0 git-lfs/3.3.0 rust/1.70.0 protobuf/3.21.3 cuda/11.8.0 cudnn/8.6.0.163 arrow/12.0.1
 
 # create env
 virtualenv --app-data $SCRATCH/virtualenv --no-download $TMP_PYENV
@@ -29,9 +33,10 @@ python -m pip install --no-index -U pip setuptools wheel build
 
 # install
 pip install --no-index --find-links $RELEASE_DIR/python_deps \
-  'accelerate<0.20.0,>=0.19.0' \
-  'einops<0.7.0,>=0.6.1' \
-  $RELEASE_DIR/python_ins/*.whl
+  $RELEASE_DIR/python_ins/flash_attn-*.whl $RELEASE_DIR/python_ins/vllm-*.whl \
+  $RELEASE_DIR/python_ins/rotary_emb-*.whl $RELEASE_DIR/python_ins/dropout_layer_norm-*.whl \
+  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/custom_kernels-*.whl \
+  "$RELEASE_DIR/python_ins/text_generation_server-1.0.1-py3-none-any.whl[bnb, accelerate, quantize]"
 export PATH="$(realpath $RELEASE_DIR/bin/)":$PATH
 
 # configure

--- a/tgi-server-mila.sh
+++ b/tgi-server-mila.sh
@@ -9,6 +9,9 @@
 #SBATCH --time=2:59:00
 set -e
 
+TGI_VERSION='1.0.2'
+FLASH_ATTN_VERSION='2.0.8'
+
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
     RELEASE_DIR=$HOME/tgi-release
@@ -20,24 +23,24 @@ if [ -z "${TMP_PYENV}" ]; then
     TMP_PYENV=$SLURM_TMPDIR/tgl-env
 fi
 
+# Load modules
+module load gcc/9.3.0
+
 # Create enviorment
 eval "$(~/bin/micromamba shell hook -s posix)"
-micromamba create -y -p $TMP_PYENV -c pytorch -c nvidia -c conda-forge 'python=3.11' 'git-lfs=3.3' 'pytorch==2.0.1' 'pytorch-cuda=11.7' 'cudnn=8.8' 'openssl=3'
+micromamba create -y -p $TMP_PYENV -c pytorch -c nvidia -c conda-forge 'python=3.11' 'git-lfs=3.3' 'pyarrow=12.0.1' 'pytorch==2.0.1' 'pytorch-cuda=11.8' 'cudnn=8.8' 'openssl=3'
 micromamba activate $TMP_PYENV
 
 # install
 pip install --no-index --find-links $RELEASE_DIR/python_deps \
-  'accelerate<0.20.0,>=0.19.0' \
-  'einops<0.7.0,>=0.6.1' \
-  $RELEASE_DIR/python_ins/*.whl
+  $RELEASE_DIR/python_ins/flash_attn-*whl $RELEASE_DIR/python_ins/vllm-*.whl \
+  $RELEASE_DIR/python_ins/rotary_emb-*.whl $RELEASE_DIR/python_ins/dropout_layer_norm-*.whl \
+  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/custom_kernels-*.whl \
+  "$RELEASE_DIR/python_ins/text_generation_server-1.0.1-py3-none-any.whl[bnb, accelerate, quantize]"
 export PATH="$(realpath $RELEASE_DIR/bin/)":$PATH
 export LD_LIBRARY_PATH=$TMP_PYENV/lib:$LD_LIBRARY_PATH
 
 # configure
-# These extentions require CUDA 11.8 and were not included in the build for Mila
-export DISABLE_EXLLAMA='true'
-export DISABLE_CUSTOM_KERNELS='true'
-
 export HUGGINGFACE_OFFLINE=1
 export HF_HUB_DISABLE_TELEMETRY=1
 export HF_HUB_ENABLE_HF_TRANSFER=1
@@ -50,7 +53,7 @@ export default_shard_usd_path=$SLURM_TMPDIR/tgl-server-socket
 export default_model_path=$TGI_DIR/tgi-repos/$MODEL_ID
 
 # start
- text-generation-launcher --model-id "${MODEL_PATH:-$default_model_path}" --num-shard "${NUM_SHARD:-$default_num_shard}" \
+text-generation-launcher --model-id "${MODEL_PATH:-$default_model_path}" --num-shard "${NUM_SHARD:-$default_num_shard}" \
   --port "${PORT:-$default_port}" \
   --master-port "${MASTER_PORT:-$default_master_port}" \
   --shard-uds-path "${SHARD_UDS_PATH:-$default_shard_usd_path}"


### PR DESCRIPTION
Update TGI to v1.0.2

Additionally:

1. This update also updates to flash-attention 2.0.8.
2. Enables the features `bnb`, `accelerate`, and `quantize`. Likely `bnb` and `accelerate` were enabled before too, but this was accidential if they were enabled, as an improper install command was used.
3. This update also enables custom kernels on Mila. This has been made possible because they have updated their CUDA drivers.
4. The compile script on compute canada is now simpler, as more modules have been added to the wheelhouse (took a lot of support tickets). I had hoped to also use their `flash_attn` wheel, but that is incompatiable with torch for CUDA 11.8, which has to be downloaded. So `flash_attn` is still compiled which takes a while. Thanksfully, it only has to be done once.

Fixes: #2
Fixes: #3
Fixes: #4