### PR TITLE
Release 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 Setups a runtime for https://github.com/huggingface/text-generation-inference, which can run nativly on
 Compute Canada and Mila clusters.
 
-
-* **TGI version:** 1.1.0
-* **enabled features:** [bnb, accelerate, quantize]
+* **TGI version:** 1.4.4
+* **enabled features:** [bnb, accelerate, quantize, peft, outlines]
 * **Flash-attention version:** 2.3.2
 
 - [Compile release](#compile-release)
@@ -274,10 +273,9 @@ https://github.com/huggingface/text-generation-inference offers a docker image o
 Best efforts are made to keep this variant of TGI as close to the docker image. However, some
 changes have been made:
 
-1. TGI Docker image uses flash-attention v2.3.0 with a fallback to flash-attention v1.0.9. Meaning both versions
+1. TGI Docker image uses flash-attention v2.4.1 with a fallback to flash-attention v1.0.9. Meaning both versions
   exists in the docker image. The older flash-attention exists to support older GPUs, however these are not used
   on Mila or Compute Canada, therefore they are not included. Also, it takes a really long time to
   compile flash-attention and two versions of flash-attention can only exist with some hacks.
-1. To include the latest fixes to flash-attention, v2.3.2 is used instead of v2.3.0.
-2. The version of some dependency packages, such as numpy, may have slighly different versions on
+1. The version of some dependency packages, such as numpy, may have slighly different versions on
   Compute Canada. This is because Compute Canada does not provide those exact versions in their wheelhouse.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,19 @@
 
 # Release notes
 
+## Release 3
+
+_April 11th, 2024_
+
+Update to TGI version 1.4.4, as well as adding `peft` and '`outlines` support,
+and including the `exllamav2` and `megablocks` kernels.
+
+On compute canada this also upgrades from `StdEnv/2020` to `StdEnv/2023`.
+
+* **TGI version:** 1.4.4
+* **enabled features:** [bnb, accelerate, quantize, peft, outlines]
+* **Flash-attention version:** 2.3.2
+
 ## Release 2
 
 _October 12th, 2023_

--- a/tgi-compile-cc.sh
+++ b/tgi-compile-cc.sh
@@ -4,17 +4,17 @@
 #SBATCH --output=%x.%j.out
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=48G
-#SBATCH --time=6:00:00
+#SBATCH --time=10:00:00
 set -e
 set -v
 
-TGI_VERSION='1.1.0'
+TGI_VERSION='1.4.4'
 FLASH_ATTN_VERSION='2.3.2'
 export MAX_JOBS=10
 
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
-    RELEASE_DIR=$HOME/tgi-release
+    RELEASE_DIR=$HOME/tgi-next
 fi
 if [ -z "${TGI_DIR}" ]; then
     TGI_DIR=$SCRATCH/tgi
@@ -31,7 +31,8 @@ echo "Storing files in $(realpath $RELEASE_DIR)"
 mkdir -p $WORK_DIR
 
 # Load modules
-module load python/3.11 gcc/9.3.0 git-lfs/3.3.0 rust/1.70.0 cmake/3.23.1 openblas/0.3.17 protobuf/3.21.3 cuda/11.8.0 cudnn/8.6.0.163 arrow/12.0.1
+module load StdEnv/2023
+module load python/3.11 git-lfs/3.4.0 rust/1.76.0 cmake/3.27.7 protobuf/24.4 arrow/14.0.1 cuda/12.2 cudnn/8.9.5.29
 export CC=$(which gcc)
 export CXX=$(which g++)
 
@@ -59,30 +60,23 @@ git checkout tags/v${TGI_VERSION} -b v${TGI_VERSION}-branch
 # download
 cd $RELEASE_DIR/python_deps
 pip download --no-deps 'mypy-protobuf==3.4.0' 'types-protobuf>=3.20.4'
-pip download --no-deps --index-url https://download.pytorch.org/whl/cu118 'torch==2.0.1'
-grep -ivE "pyarrow" $WORK_DIR/text-generation-inference/server/requirements.txt > $WORK_DIR/requirements.txt
-pip download --no-deps -r $WORK_DIR/requirements.txt
-pip download 'bitsandbytes<0.42.0,>=0.41.1' # bnb
+grep -ivE "pyarrow|scipy|numpy" $WORK_DIR/text-generation-inference/server/requirements_cuda.txt > $WORK_DIR/requirements_cuda.txt
+pip download --no-deps -r $WORK_DIR/requirements_cuda.txt
+pip download 'bitsandbytes<0.44.0,>=0.43.0' # bnb
 pip download 'datasets<3.0.0,>=2.14.0' 'texttable<2.0.0,>=1.6.7' # quantize
-pip download 'accelerate<0.21.0,>=0.20.0' # accelerate
+pip download 'accelerate<0.29.0,>=0.28.0' # accelerate
+pip download 'peft<0.10.0,>=0.9.0' # peft
+pip download --no-deps 'outlines<0.0.37,>=0.0.36' 'interegular==0.3.3' # outlines
 pip download --no-deps 'poetry-core>=1.6.1' # build dependencies
 
 # cleanup dependencies where another acceptable version is provided by compute canada
 rm -f *+computecanada*.whl
-rm -f safetensors-* aiohttp-* frozenlist-* numpy-* scipy-* pandas-* pyarrow-* xxhash-* yarl-* Pillow-*
-
-# Compile grpcio
-tar xvf grpcio-1.58.0.tar.gz
-cd grpcio-1.58.0
-python -m build
-cp dist/grpcio-1.58.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_deps/
-cd $RELEASE_DIR/python_deps
-rm -rf grpcio-1.58.0 grpcio-1.58.0.tar.gz
+rm -f grpcio-* tokenizers-* MarkupSafe-* safetensors-* aiohttp-* frozenlist-* numpy-* scipy-* pandas-* pyarrow-* xxhash-* yarl-* Pillow-* regex-* psutil-* hf_transfer-*
 
 ####
 # BUILD tgi
 ####
-pip install --no-index --find-links $RELEASE_DIR/python_deps "torch==2.0.1"
+pip install --no-index --find-links $RELEASE_DIR/python_deps "torch==2.1.2"
 pip install --no-index --find-links $RELEASE_DIR/python_deps packaging
 
 #
@@ -99,7 +93,7 @@ touch text_generation_server/pb/__init__.py
 rm text_generation_server/pb/.gitignore
 # build package
 pip install --no-index --find-links $RELEASE_DIR/python_deps -U 'poetry-core>=1.6.1'
-pip wheel --no-deps --no-index --find-links $RELEASE_DIR/python_deps ".[bnb, accelerate, quantize]"
+pip wheel --no-deps --no-index --find-links $RELEASE_DIR/python_deps ".[bnb, accelerate, quantize, peft, outlines]"
 cp "text_generation_server-${TGI_VERSION}-py3-none-any.whl" $RELEASE_DIR/python_ins/
 
 #
@@ -137,7 +131,8 @@ NV_CC="8.0;8.6" # flash-attention-v2 and exllama_kernels are anyway limited to C
 cd $WORK_DIR/text-generation-inference/server
 git clone https://github.com/Dao-AILab/flash-attention flash-attention-v2
 cd $WORK_DIR/text-generation-inference/server/flash-attention-v2
-git checkout tags/v${FLASH_ATTN_VERSION}
+git checkout '02ac572f3ffc4f402e4183aaa6824b45859d3ed3'
+git submodule update --init --recursive
 
 # With 48GB of memory, MAX_JOBS=4 is as high as it goes.
 cd $WORK_DIR/text-generation-inference/server/flash-attention-v2
@@ -163,16 +158,22 @@ cp dropout_layer_norm-0.1-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 # vllm
 cd $WORK_DIR/text-generation-inference/server
-TORCH_CUDA_ARCH_LIST=$NV_CC make build-vllm
+TORCH_CUDA_ARCH_LIST=$NV_CC make build-vllm-cuda
 cd $WORK_DIR/text-generation-inference/server/vllm
+sed -i 's/torch == 2.0.1/torch/g' pyproject.toml
+sed -i 's/torch == 2.0.1/torch/g' requirements.txt
+sed -i 's/pydantic < 2/pydantic/g' requirements.txt
+sed -i 's/xformers == 0.0.22/xformers/g' requirements.txt
 TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
-wheel convert dist/vllm-0.0.0-py3.11-linux-x86_64.egg
-wheel tags --python-tag=cp311 vllm-0.0.0-py311-cp311-linux_x86_64.whl
-cp vllm-0.0.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
+wheel convert dist/vllm-0.2.1-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 vllm-0.2.1-py311-cp311-linux_x86_64.whl
+cp vllm-0.2.1-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 # awq
 cd $WORK_DIR/text-generation-inference/server
-TORCH_CUDA_ARCH_LIST=$NV_CC+PTX make build-awq
+export TORCH_CUDA_ARCH_LIST=$NV_CC+PTX
+make build-awq || make build-awq || make build-awq
+export -n TORCH_CUDA_ARCH_LIST
 cd $WORK_DIR/text-generation-inference/server/llm-awq/awq/kernels
 TORCH_CUDA_ARCH_LIST=$NV_CC+PTX python setup.py bdist_egg
 wheel convert dist/awq_inference_engine-0.0.0-py3.11-linux-x86_64.egg
@@ -196,6 +197,14 @@ wheel convert dist/exllama_kernels-0.0.0-py3.11-linux-x86_64.egg
 wheel tags --python-tag=cp311 exllama_kernels-0.0.0-py311-cp311-linux_x86_64.whl
 cp exllama_kernels-0.0.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
+# exllamav2_kernels
+cd $WORK_DIR/text-generation-inference/server/exllamav2_kernels
+TORCH_CUDA_ARCH_LIST=$NV_CC+PTX python setup.py build
+TORCH_CUDA_ARCH_LIST=$NV_CC+PTX python setup.py bdist_egg
+wheel convert dist/exllamav2_kernels-0.0.0-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 exllamav2_kernels-0.0.0-py311-cp311-linux_x86_64.whl
+cp exllamav2_kernels-0.0.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
+
 # custom_kernels
 cd $WORK_DIR/text-generation-inference/server/custom_kernels
 TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py build
@@ -203,6 +212,35 @@ TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
 wheel convert dist/custom_kernels-0.0.0-py3.11-linux-x86_64.egg
 wheel tags --python-tag=cp311 custom_kernels-0.0.0-py311-cp311-linux_x86_64.whl
 cp custom_kernels-0.0.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
+
+# Build mamba kernels
+cd $WORK_DIR/text-generation-inference/server
+TORCH_CUDA_ARCH_LIST=$NV_CC make build-all
+cd $WORK_DIR/text-generation-inference/server/causal-conv1d
+TORCH_CUDA_ARCH_LIST=$NV_CC CAUSAL_CONV1D_FORCE_BUILD=TRUE python setup.py bdist_egg
+wheel convert dist/causal_conv1d-1.1.1-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 causal_conv1d-1.1.1-py311-cp311-linux_x86_64.whl
+cp causal_conv1d-1.1.1-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
+cd $WORK_DIR/text-generation-inference/server/mamba
+TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
+wheel convert dist/mamba_ssm-1.1.2-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 mamba_ssm-1.1.2-py311-cp311-linux_x86_64.whl
+cp mamba_ssm-1.1.2-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
+
+# megablocks
+cd $RELEASE_DIR/python_deps
+pip wheel --no-deps --no-index --find-links $RELEASE_DIR/python_deps "git+https://github.com/OlivierDehaene/stk@0536f762df7a406de508d17a0ee4c124e8ad7f06"
+
+cd $WORK_DIR/
+git clone https://github.com/OlivierDehaene/megablocks.git
+cd megablocks
+git checkout "181709df192de9a941fdf3a641cdc65a0462996e"
+sed -i 's#stanford-stk @ git+https://github.com/OlivierDehaene/stk.git@0536f762df7a406de508d17a0ee4c124e8ad7f06#stanford-stk#g' setup.py
+sed -i 's#stanford-stk @ git+https://github.com/OlivierDehaene/stk.git@0536f762df7a406de508d17a0ee4c124e8ad7f06#stanford-stk#g' requirements.txt
+TORCH_CUDA_ARCH_LIST=$NV_CC python setup.py bdist_egg
+wheel convert dist/megablocks-0.5.0-py3.11-linux-x86_64.egg
+wheel tags --python-tag=cp311 megablocks-0.5.0-py311-cp311-linux_x86_64.whl
+cp megablocks-0.5.0-cp311-cp311-linux_x86_64.whl $RELEASE_DIR/python_ins/
 
 echo "***************************"
 echo "* COMPILE JOB SUCCESSFULL *"

--- a/tgi-download-cc.sh
+++ b/tgi-download-cc.sh
@@ -7,12 +7,12 @@
 #SBATCH --time=1:00:00
 set -e
 
-TGI_VERSION='1.1.0'
+TGI_VERSION='1.4.4'
 FLASH_ATTN_VERSION='2.3.2'
 
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
-    RELEASE_DIR=$HOME/tgi-release
+    RELEASE_DIR=$HOME/tgi-next
 fi
 if [ -z "${TGI_DIR}" ]; then
     TGI_DIR=$SCRATCH/tgi
@@ -24,7 +24,8 @@ fi
 echo "Downloading ${MODEL_ID}"
 
 # Load modules
-module load python/3.11 gcc/9.3.0 git-lfs/3.3.0 protobuf/3.21.3 cuda/11.8.0 cudnn/8.6.0.163 arrow/12.0.1
+module load StdEnv/2023
+module load python/3.11 git-lfs/3.4.0 protobuf/24.4 arrow/14.0.1 cuda/12.2 cudnn/8.9.5.29
 
 # create env
 virtualenv --app-data $SCRATCH/virtualenv --no-download $TGI_TMP/pyenv
@@ -36,8 +37,10 @@ pip install --no-index --find-links $RELEASE_DIR/python_deps \
   $RELEASE_DIR/python_ins/flash_attn-*.whl $RELEASE_DIR/python_ins/vllm-*.whl \
   $RELEASE_DIR/python_ins/rotary_emb-*.whl $RELEASE_DIR/python_ins/dropout_layer_norm-*.whl \
   $RELEASE_DIR/python_ins/awq_inference_engine-*.whl $RELEASE_DIR/python_ins/EETQ-*.whl \
-  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/custom_kernels-*.whl \
-  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize]"
+  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/exllamav2_kernels-*.whl \
+  $RELEASE_DIR/python_ins/custom_kernels-*.whl $RELEASE_DIR/python_ins/megablocks-*.whl \
+  $RELEASE_DIR/python_ins/causal_conv1d-*.whl $RELEASE_DIR/python_ins/mamba_ssm-*.whl \
+  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize, peft, outlines]"
 
 export PATH="$(realpath $RELEASE_DIR/bin/)":$PATH
 

--- a/tgi-download-mila.sh
+++ b/tgi-download-mila.sh
@@ -6,12 +6,12 @@
 #SBATCH --time=1:00:00
 set -e
 
-TGI_VERSION='1.1.0'
+TGI_VERSION='1.4.4'
 FLASH_ATTN_VERSION='2.3.2'
 
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
-    RELEASE_DIR=$HOME/tgi-release
+    RELEASE_DIR=$HOME/tgi-next
 fi
 if [ -z "${TGI_DIR}" ]; then
     TGI_DIR=$SCRATCH/tgi
@@ -22,12 +22,10 @@ fi
 
 echo "Downloading ${MODEL_ID}"
 
-# Load modules
-module load gcc/9.3.0
-
-# Create env
+# Create environment
+# default gcc version 11.4.0
 eval "$(~/bin/micromamba shell hook -s posix)"
-micromamba create -y -p $TGI_TMP/pyenv -c pytorch -c nvidia -c conda-forge 'python=3.11' 'git-lfs=3.3' 'pyarrow=12.0.1' 'pytorch==2.0.1' 'pytorch-cuda=11.8' 'cudnn=8.8' 'openssl=3'
+micromamba create -y -p $TGI_TMP/pyenv -c pytorch -c "nvidia/label/cuda-12.1.1" -c "nvidia/label/cuda-12.1.0" -c conda-forge --channel-priority flexible 'python=3.11' 'git-lfs=3.3' 'pyarrow=14.0.2' 'pytorch==2.1.1' 'pytorch-cuda=12.1' cuda-nvcc cuda-toolkit cuda-libraries-dev 'cudnn=8.8' 'openssl=3' 'ninja=1'
 micromamba activate $TGI_TMP/pyenv
 
 # install
@@ -35,8 +33,11 @@ pip install --no-index --find-links $RELEASE_DIR/python_deps \
   $RELEASE_DIR/python_ins/flash_attn-*.whl $RELEASE_DIR/python_ins/vllm-*.whl \
   $RELEASE_DIR/python_ins/rotary_emb-*.whl $RELEASE_DIR/python_ins/dropout_layer_norm-*.whl \
   $RELEASE_DIR/python_ins/awq_inference_engine-*.whl $RELEASE_DIR/python_ins/EETQ-*.whl \
-  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/custom_kernels-*.whl \
-  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize]"
+  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/exllamav2_kernels-*.whl \
+  $RELEASE_DIR/python_ins/custom_kernels-*.whl $RELEASE_DIR/python_ins/megablocks-*.whl \
+  $RELEASE_DIR/python_ins/causal_conv1d-*.whl $RELEASE_DIR/python_ins/mamba_ssm-*.whl \
+  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize, peft, outlines]"
+
 export PATH="$(realpath $RELEASE_DIR/bin/)":$PATH
 export LD_LIBRARY_PATH=$TGI_TMP/pyenv/lib:$LD_LIBRARY_PATH
 

--- a/tgi-server-cc.sh
+++ b/tgi-server-cc.sh
@@ -9,12 +9,12 @@
 #SBATCH --time=2:59:00
 set -e
 
-TGI_VERSION='1.1.0'
+TGI_VERSION='1.4.4'
 FLASH_ATTN_VERSION='2.3.2'
 
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
-    RELEASE_DIR=$HOME/tgi-release
+    RELEASE_DIR=$HOME/tgi-next
 fi
 if [ -z "${TGI_DIR}" ]; then
     TGI_DIR=$SCRATCH/tgi
@@ -24,7 +24,8 @@ if [ -z "${TGI_TMP}" ]; then
 fi
 
 # Load modules
-module load python/3.11 gcc/9.3.0 git-lfs/3.3.0 protobuf/3.21.3 cuda/11.8.0 cudnn/8.6.0.163 arrow/12.0.1
+module load StdEnv/2023
+module load python/3.11 git-lfs/3.4.0 protobuf/24.4 arrow/14.0.1 cuda/12.2 cudnn/8.9.5.29
 
 # create env
 virtualenv --app-data $SCRATCH/virtualenv --no-download $TGI_TMP/pyenv
@@ -36,8 +37,10 @@ pip install --no-index --find-links $RELEASE_DIR/python_deps \
   $RELEASE_DIR/python_ins/flash_attn-*.whl $RELEASE_DIR/python_ins/vllm-*.whl \
   $RELEASE_DIR/python_ins/rotary_emb-*.whl $RELEASE_DIR/python_ins/dropout_layer_norm-*.whl \
   $RELEASE_DIR/python_ins/awq_inference_engine-*.whl $RELEASE_DIR/python_ins/EETQ-*.whl \
-  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/custom_kernels-*.whl \
-  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize]"
+  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/exllamav2_kernels-*.whl \
+  $RELEASE_DIR/python_ins/custom_kernels-*.whl $RELEASE_DIR/python_ins/megablocks-*.whl \
+  $RELEASE_DIR/python_ins/causal_conv1d-*.whl $RELEASE_DIR/python_ins/mamba_ssm-*.whl \
+  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize, peft, outlines]"
 export PATH="$(realpath $RELEASE_DIR/bin/)":$PATH
 
 # configure

--- a/tgi-server-mila.sh
+++ b/tgi-server-mila.sh
@@ -9,12 +9,12 @@
 #SBATCH --time=2:59:00
 set -e
 
-TGI_VERSION='1.1.0'
+TGI_VERSION='1.4.4'
 FLASH_ATTN_VERSION='2.3.2'
 
 # Default config
 if [ -z "${RELEASE_DIR}" ]; then
-    RELEASE_DIR=$HOME/tgi-release
+    RELEASE_DIR=$HOME/tgi-next
 fi
 if [ -z "${TGI_DIR}" ]; then
     TGI_DIR=$SCRATCH/tgi
@@ -23,21 +23,21 @@ if [ -z "${TGI_TMP}" ]; then
     TGI_TMP=$SLURM_TMPDIR/tgi
 fi
 
-# Load modules
-module load gcc/9.3.0
-
-# Create enviorment
+# Create environment
+# default gcc version 11.4.0
 eval "$(~/bin/micromamba shell hook -s posix)"
-micromamba create -y -p $TGI_TMP/pyenv -c pytorch -c nvidia -c conda-forge 'python=3.11' 'git-lfs=3.3' 'pyarrow=12.0.1' 'pytorch==2.0.1' 'pytorch-cuda=11.8' 'cudnn=8.8' 'openssl=3'
+micromamba create -y -p $TGI_TMP/pyenv -c pytorch -c "nvidia/label/cuda-12.1.1" -c "nvidia/label/cuda-12.1.0" -c conda-forge --channel-priority flexible 'python=3.11' 'git-lfs=3.3' 'pyarrow=14.0.2' 'pytorch==2.1.1' 'pytorch-cuda=12.1' cuda-nvcc cuda-toolkit cuda-libraries-dev 'cudnn=8.8' 'openssl=3' 'ninja=1'
 micromamba activate $TGI_TMP/pyenv
 
 # install
 pip install --no-index --find-links $RELEASE_DIR/python_deps \
-  $RELEASE_DIR/python_ins/flash_attn-*whl $RELEASE_DIR/python_ins/vllm-*.whl \
+  $RELEASE_DIR/python_ins/flash_attn-*.whl $RELEASE_DIR/python_ins/vllm-*.whl \
   $RELEASE_DIR/python_ins/rotary_emb-*.whl $RELEASE_DIR/python_ins/dropout_layer_norm-*.whl \
   $RELEASE_DIR/python_ins/awq_inference_engine-*.whl $RELEASE_DIR/python_ins/EETQ-*.whl \
-  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/custom_kernels-*.whl \
-  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize]"
+  $RELEASE_DIR/python_ins/exllama_kernels-*.whl $RELEASE_DIR/python_ins/exllamav2_kernels-*.whl \
+  $RELEASE_DIR/python_ins/custom_kernels-*.whl $RELEASE_DIR/python_ins/megablocks-*.whl \
+  $RELEASE_DIR/python_ins/causal_conv1d-*.whl $RELEASE_DIR/python_ins/mamba_ssm-*.whl \
+  "$RELEASE_DIR/python_ins/text_generation_server-$TGI_VERSION-py3-none-any.whl[bnb, accelerate, quantize, peft, outlines]"
 export PATH="$(realpath $RELEASE_DIR/bin/)":$PATH
 export LD_LIBRARY_PATH=$TGI_TMP/pyenv/lib:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
Update to TGI version 1.4.4, as well as adding `peft` and '`outlines` support, and including the `exllamav2` and `megablocks` kernels.

On compute canada this also upgrades from `StdEnv/2020` to `StdEnv/2023`.

* **TGI version:** 1.4.4
* **enabled features:** [bnb, accelerate, quantize, peft, outlines]
* **Flash-attention version:** 2.3.2
